### PR TITLE
Update: Improve model logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes for the CiviEmailEngagement extension will be noted here.
 
+## [2.1.0] - 2024-12-05
+### Changed
+- ContactEmailEngagement records are now deleted when there are no trackable URL
+  clicks in the reporting period rather than mailings delivered
+- Coding style changes
+
 ## [2.0.0] - 2024-10-08
 ### Changed
 - BREAKING: The extension now uses Entity Framework version 2. This limits use of
@@ -9,22 +15,18 @@ All notable changes for the CiviEmailEngagement extension will be noted here.
   of CiviCRM will be unable to install and use the extension at all.
 
 ## [1.0.3] - 2024-06-25
-
 ### Changed
 - Fixed bug in refreshExpired function
 
 ## [1.0.2] - 2024-06-20
-
 ### Changed
 - Removed unused JOIN in API4 call
 
 ## [1.0.1] - 2024-06-19
-
 ### Changed
 - Fixed bug in reporting period definition
 - Fixed issue where Models tab would render empty content for contacts with no EE record
 - Fixed unbalanced single/double quotes in Smarty template
 
 ## [1.0.0] - 2024-06-17
-
 Initial release candidate of the CiviEmailEngagement extension.

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
   },
   "support": "https://github.com/australiangreens/civiemailengagement/issues",
   "type": "civicrm-ext",
-  "version": "2.0.0"
+  "version": "2.1.0"
   }
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/australiangreens/civiemailengagement</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2024-10-08</releaseDate>
-  <version>2.0.0</version>
+  <releaseDate>2024-12-05</releaseDate>
+  <version>2.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.70</ver>


### PR DESCRIPTION
This PR makes a small but significant change: it now uses the volume of trackable URLs clicked within the reporting period as the basis for understanding if/when a record should be deleted. This is a better reflection of the intent of the model overall.

Tested successfully by finding an existing record with a NULL value for clicked URLs, performing the calculation, and confirming the record had been properly removed.